### PR TITLE
Numpy 2 support and new python support 3.10 - 3.14

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,8 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.8", "3.9", "3.10","3.11" ]
-        pandas-version: [ "1.5.3", "2.0.3", "2.*" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        pandas-version: [ "2.2.2", "2.*" ]
+        exclude:
+          - python-version: "3.13"
+            pandas-version: "2.2.2"
+          - python-version: "3.14"
+            pandas-version: "2.2.2"
 
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ conda install -c conda-forge eccodes
 or you can install the official source distribution, follow the
 instructions [here](https://github.com/ecmwf/cfgrib) <br />
 
+## Legacy numpy 1 / pandas 1.5.3 support
+
+As of `v1.0.b10`, S5 supports numpy 1.x and pandas >=1.5.0 (including 1.5.3).
+From `v1.0.b11` onward, S5 requires numpy 2 and pandas >=2.2.2 — the two are
+mutually incompatible, so numpy1/pandas1.5.3 support is frozen at `v1.0.b10`
+and will not receive further updates.
+
+Pipelines that still depend on numpy 1.x or pandas 1.5.3 should pin their
+install to the frozen tag:
+
+```shell
+pip install git+https://github.com/owentmfoo/S5@v1.0.b10
+```
+

--- a/S5/HPC/optimisation.py
+++ b/S5/HPC/optimisation.py
@@ -26,7 +26,7 @@ def set_mean(vel, v_bar, x, n, clip=None):
     :param clip: clipping to reduce spikes, None, "kph", or "ms"
     """
     velout = 'spam'
-    vel = np.copy(v_bar + vel - np.trapz(vel, x) / (x.max() - x.min()))
+    vel = np.copy(v_bar + vel - np.trapezoid(vel, x) / (x.max() - x.min()))
     if clip is None:
         velout = vel
     elif clip == "kph":
@@ -48,7 +48,7 @@ def set_mean(vel, v_bar, x, n, clip=None):
         velout = vel
         warnings.warn("clip specifier not valid, no clip is applied.")
 
-    if np.isclose(np.trapz(velout, x) / (x.max() - x.min()), v_bar):
+    if np.isclose(np.trapezoid(velout, x) / (x.max() - x.min()), v_bar):
         return velout.copy()
     # Old implementation by recursion. Keep until current implementation tested with real data.
     # else:
@@ -58,12 +58,12 @@ def set_mean(vel, v_bar, x, n, clip=None):
     #         warnings.warn(f'max recursion reached with v_bar = {v_bar}')
     #     return velout.copy()
     velout = _set_mean_clip_optifun(vel, v_bar, x, n, clip=clip)
-    current_delta = np.trapz(velout, x) / (x.max() - x.min()) - v_bar  # delta is positive if the actual is larger
+    current_delta = np.trapezoid(velout, x) / (x.max() - x.min()) - v_bar  # delta is positive if the actual is larger
     # than the target
     adjust = v_bar - current_delta  # if the actual is larger than target, take some off
     while not math.isclose(current_delta, 0, abs_tol=1e-12):
         velout = _set_mean_clip_optifun(vel, v_bar + adjust, x, n, clip=clip)
-        current_delta = np.trapz(velout, x) / (x.max() - x.min()) - v_bar
+        current_delta = np.trapezoid(velout, x) / (x.max() - x.min()) - v_bar
         adjust -= current_delta
 
     # v_bar = v_bar + adjust
@@ -83,7 +83,7 @@ def _set_mean_clip_optifun(vel, v_bar, x, n, clip=None):
     :param n: precision in decimal points
     :param clip: clipping to reduce spikes, None, "kph", or "ms"
     """
-    vel = np.copy(v_bar + vel - np.trapz(vel, x) / (x.max() - x.min()))
+    vel = np.copy(v_bar + vel - np.trapezoid(vel, x) / (x.max() - x.min()))
     if clip is None:
         velout = vel
     elif clip == "kph":
@@ -97,8 +97,8 @@ def _set_mean_clip_optifun(vel, v_bar, x, n, clip=None):
 
 
 def extract_prime(vel, x, n):
-    v_prime = vel - np.trapz(vel, x) / (x.max() - x.min())
-    assert round(np.trapz(v_prime, x), round(n)) == 0
+    v_prime = vel - np.trapezoid(vel, x) / (x.max() - x.min())
+    assert round(np.trapezoid(v_prime, x), round(n)) == 0
     return v_prime
     # else:
     #     try:

--- a/S5/__init__.py
+++ b/S5/__init__.py
@@ -4,4 +4,4 @@ A module to be used in conjunction with SolarSim, to prepare input data, run Sol
 results.
 """
 
-__version__ = "1.0.b10"
+__version__ = "1.0.b11"

--- a/S5/tests/test_optimisation.py
+++ b/S5/tests/test_optimisation.py
@@ -31,7 +31,7 @@ def test_set_mean_clip_kph_lin():
     y = x.copy()
     y[random.randint(0, 100)] = 100
     z = set_mean(y, 70, x, 8, 'kph')
-    assert np.trapz(z, x) / (x.max() - x.min()) == approx(70)
+    assert np.trapezoid(z, x) / (x.max() - x.min()) == approx(70)
     assert z.max() == approx(130)
 
 
@@ -42,7 +42,7 @@ def test_set_mean_clip_kph():
     z = set_mean(y, v_bar, x, 8, 'kph')
     assert z.max() == approx(130)
     assert z.min() == approx(10)
-    assert np.trapz(z, x) / (x.max() - x.min()) == approx(v_bar)
+    assert np.trapezoid(z, x) / (x.max() - x.min()) == approx(v_bar)
 
 
 def test_set_mean_clip_ms():
@@ -52,7 +52,7 @@ def test_set_mean_clip_ms():
     z = set_mean(y, v_bar, x, 8, 'ms')
     assert z.max() == approx(130 / 3.6)
     assert z.min() == approx(10 / 3.6)
-    assert np.trapz(z, x) / (x.max() - x.min()) == approx(v_bar)
+    assert np.trapezoid(z, x) / (x.max() - x.min()) == approx(v_bar)
 
 
 def test_calc_strat_zero():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "S5"
 authors = [{name = "Owen Foo", email = "owentmfoo@gmail.com"}]
 readme = "README.md"
-requires-python=">=3.6"
+requires-python=">=3.10"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
@@ -16,12 +16,12 @@ classifiers = [
 dynamic = ["version", "description",]
 
 dependencies = [
-    "pandas[parquet] >= 1.5.0",
+    "pandas[parquet] >= 2.2.2, < 3",
     "pvlib",
     "pytz",
-    "matplotlib >= 3.5.0",
+    "matplotlib >= 3.8.4",
     "tqdm",
-    "numpy >= 1.20.3, < 2",
+    "numpy >= 2.0",
     "pytest >= 7.1.1",
     "setuptools >= 58.0.4",
     "pyarrow >=8.0.0",


### PR DESCRIPTION
* updated dependency files for numpy and python versions, assocated CI matrix
* fixed np.trapz - breaking change from numpy 1 to 2

Note:
* numpy1/pandas1.5.3 support is frozen at tag `v1.0.b10` to used a specific version, 
```shell
pip install git+https://github.com/owentmfoo/S5@v1.0.b10
```